### PR TITLE
Fixed a server crash caused by kicking a user with PlayerJoinEvent

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -3,7 +3,4 @@
 # IMPORTANT: Keep in mind this is NOT for the visible parts of the skin, it is for the entire skin texture, which
 # normally already contains a good amount of empty pixels.
 percentage: 75
-
-# The message to kick the player with.
-message: "Invisible skins are not allowed."
 ...

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -3,4 +3,7 @@
 # IMPORTANT: Keep in mind this is NOT for the visible parts of the skin, it is for the entire skin texture, which
 # normally already contains a good amount of empty pixels.
 percentage: 75
+
+# The message to kick the player with.
+message: "Invisible skins are not allowed."
 ...

--- a/src/Unickorn/InvisibleSkinBlocker/Main.php
+++ b/src/Unickorn/InvisibleSkinBlocker/Main.php
@@ -8,6 +8,7 @@ use pocketmine\event\player\PlayerChangeSkinEvent;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\player\Player;
 use pocketmine\plugin\PluginBase;
+use pocketmine\scheduler\ClosureTask;
 use function ord;
 use function strlen;
 
@@ -34,6 +35,9 @@ class Main extends PluginBase implements Listener
 	}
 
 	public function checkSkin(Player $player, ?string $skinData = null) : void {
+		if(!$player->isOnline()){
+			return;
+		}
 		$skinData ??= $player->getSkin()->getSkinData();
 		$size = strlen($skinData);
 		$width = self::SKIN_WIDTH_MAP[$size];
@@ -53,7 +57,10 @@ class Main extends PluginBase implements Listener
 	}
 
 	public function onJoin(PlayerJoinEvent $event) : void {
-		$this->checkSkin($event->getPlayer());
+		$player = $event->getPlayer();
+		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(function() use ($player): void{
+			$this->checkSkin($player);
+		}), 1);
 	}
 
 	public function onChangeSkin(PlayerChangeSkinEvent $event) : void {

--- a/src/Unickorn/InvisibleSkinBlocker/Main.php
+++ b/src/Unickorn/InvisibleSkinBlocker/Main.php
@@ -40,7 +40,6 @@ class Main extends PluginBase implements Listener
 		$height = self::SKIN_HEIGHT_MAP[$size];
 		$pos = -1;
 		$pixelsNeeded = (int)((100 - $this->percentage) / 100 * ($width * $height)); // visible pixels needed
-
 		for ($y = 0; $y < $height; $y++) {
 			for ($x = 0; $x < $width; $x++) {
 				if (ord($skinData[$pos += 4]) === 255) {
@@ -54,7 +53,6 @@ class Main extends PluginBase implements Listener
 	}
 
 	public function onJoin(PlayerLoginEvent $event) : void {
-		var_dump($this->checkSkin($event->getPlayer()));
 		if($this->checkSkin($event->getPlayer())){
 			$event->setKickMessage($this->message);
 			$event->cancel();

--- a/src/Unickorn/InvisibleSkinBlocker/Main.php
+++ b/src/Unickorn/InvisibleSkinBlocker/Main.php
@@ -40,29 +40,31 @@ class Main extends PluginBase implements Listener
 		$height = self::SKIN_HEIGHT_MAP[$size];
 		$pos = -1;
 		$pixelsNeeded = (int)((100 - $this->percentage) / 100 * ($width * $height)); // visible pixels needed
+
 		for ($y = 0; $y < $height; $y++) {
 			for ($x = 0; $x < $width; $x++) {
 				if (ord($skinData[$pos += 4]) === 255) {
 					if (--$pixelsNeeded === 0) {
-						return true;
+						return false;
 					}
 				}
 			}
 		}
-		return false;
+		return true;
 	}
 
 	public function onJoin(PlayerLoginEvent $event) : void {
-		$player = $event->getPlayer();
+		var_dump($this->checkSkin($event->getPlayer()));
 		if($this->checkSkin($event->getPlayer())){
 			$event->setKickMessage($this->message);
-			//$player->setSkin(new Skin("Standard_Custom", str_repeat(random_bytes(3) . "\xff", 4096)));
+			$event->cancel();
 		}
 	}
 
 	public function onChangeSkin(PlayerChangeSkinEvent $event) : void {
-		if($this->checkSkin($event->getPlayer(), $event->getNewSkin()->getSkinData())){
-			$event->cancel();
+		$player = $event->getPlayer();
+		if($this->checkSkin($player, $event->getNewSkin()->getSkinData())){
+			$player->kick($this->message);
 		}
 	}
 }

--- a/src/Unickorn/InvisibleSkinBlocker/Main.php
+++ b/src/Unickorn/InvisibleSkinBlocker/Main.php
@@ -11,6 +11,10 @@ use pocketmine\plugin\PluginBase;
 use function ord;
 use function strlen;
 use pocketmine\entity\Skin;
+use pocketmine\event\server\DataPacketReceiveEvent;
+use pocketmine\network\mcpe\protocol\PlayerSkinPacket;
+use pocketmine\event\server\DataPacketSendEvent;
+use pocketmine\event\player\PlayerLoginEvent;
 
 class Main extends PluginBase implements Listener
 {
@@ -26,10 +30,12 @@ class Main extends PluginBase implements Listener
 	];
 
 	private int $percentage;
+	private string $message;
 
 	public function onEnable() : void {
 		$this->getServer()->getPluginManager()->registerEvents($this, $this);
 		$this->percentage = $this->getConfig()->get("percentage", 75);
+		$this->message = $this->getConfig()->get("message", "Invisible skins are not allowed.");
 	}
 
 	public function checkSkin(Player $player, ?string $skinData = null) : bool {
@@ -51,10 +57,11 @@ class Main extends PluginBase implements Listener
 		return false;
 	}
 
-	public function onJoin(PlayerJoinEvent $event) : void {
+	public function onJoin(PlayerLoginEvent $event) : void {
 		$player = $event->getPlayer();
 		if($this->checkSkin($event->getPlayer())){
-			$player->setSkin(new Skin("Standard_Custom", str_repeat(random_bytes(3) . "\xff", 4096)));
+			$event->setKickMessage($this->message);
+			//$player->setSkin(new Skin("Standard_Custom", str_repeat(random_bytes(3) . "\xff", 4096)));
 		}
 	}
 

--- a/src/Unickorn/InvisibleSkinBlocker/Main.php
+++ b/src/Unickorn/InvisibleSkinBlocker/Main.php
@@ -11,7 +11,6 @@ use pocketmine\plugin\PluginBase;
 use function ord;
 use function strlen;
 
-
 class Main extends PluginBase implements Listener
 {
 	public const SKIN_WIDTH_MAP = [


### PR DESCRIPTION
## credits
[Niziebi](https://github.com/Niziebi)
[boymelancholy](https://github.com/boymelancholy)
and more
## console
```
[20:25:17.042] [Server thread/INFO]: [NetworkSession: ] Session closed due to Invisible skins are not allowed.
[20:25:17.044] [RakLib thread/DEBUG]: [Session: 127.0.0.1 58246] Requesting graceful disconnect because "server disconnect"
[20:25:17.046] [Server thread/INFO]:  left the game
[20:25:17.047] [RakLib thread/DEBUG]: [Session: 127.0.0.1 58246] All pending traffic flushed, sent disconnect notification
[20:25:17.053] [Server thread/INFO]:  joined the game
[20:25:17.057] [Server thread/CRITICAL]: TypeError: "pocketmine\network\mcpe\handler\InGamePacketHandler::__construct(): Argument #3 ($inventoryManager) must be of type pocketmine\network\mcpe\InventoryManager, null given, called in phar://P:/game/PocketMine-MP.phar/src/network/mcpe/NetworkSession.php on line 716" (EXCEPTION) in "pmsrc/src/network/mcpe/handler/InGamePacketHandler" at line 156
--- Stack trace ---
  #0 pmsrc/src/network/mcpe/NetworkSession(716): pocketmine\network\mcpe\handler\InGamePacketHandler->__construct(object pocketmine\player\Player#33772, object pocketmine\network\mcpe\NetworkSession#33371, NULL )
  #1 pmsrc/src/network/mcpe/NetworkSession(707): pocketmine\network\mcpe\NetworkSession->onClientSpawnResponse()
  #2 pmsrc/src/network/mcpe/handler/SpawnResponsePacketHandler(44): pocketmine\network\mcpe\NetworkSession->pocketmine\network\mcpe\{closure}()
  #3 pmsrc/vendor/pocketmine/bedrock-protocol/src/SetLocalPlayerAsInitializedPacket(42): pocketmine\network\mcpe\handler\SpawnResponsePacketHandler->handleSetLocalPlayerAsInitialized(object pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket#130942)
  #4 pmsrc/src/network/mcpe/NetworkSession(398): pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket->handle(object pocketmine\network\mcpe\handler\SpawnResponsePacketHandler#103828)
  #5 pmsrc/src/network/mcpe/NetworkSession(361): pocketmine\network\mcpe\NetworkSession->handleDataPacket(object pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket#130942, string[2] q.)
  #6 pmsrc/src/network/mcpe/raklib/RakLibInterface(192): pocketmine\network\mcpe\NetworkSession->handleEncoded(string[55] c*d2...../....e.t....t......@...L. ....{A4."...*.......)
  #7 pmsrc/vendor/pocketmine/raklib-ipc/src/RakLibToUserThreadMessageReceiver(42): pocketmine\network\mcpe\raklib\RakLibInterface->onPacketReceive(integer 0, string[64] ..9.q..6...Bc..u^..X.....xs....{..a......t+.....n.0..q......C..2)
  #8 pmsrc/src/network/mcpe/raklib/RakLibInterface(122): raklib\server\ipc\RakLibToUserThreadMessageReceiver->handle(object pocketmine\network\mcpe\raklib\RakLibInterface#33356)
  #9 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(123): pocketmine\network\mcpe\raklib\RakLibInterface->pocketmine\network\mcpe\raklib\{closure}()
  #10 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(82): pocketmine\snooze\SleeperHandler->processNotifications()
  #11 pmsrc/src/Server(1661): pocketmine\snooze\SleeperHandler->sleepUntil(double 1652703917.0314)
  #12 pmsrc/src/Server(1047): pocketmine\Server->tickProcessor()
  #13 pmsrc/src/PocketMine(304): pocketmine\Server->__construct(object BaseClassLoader#2, object pocketmine\utils\MainLogger#3, string[8] P:\game\, string[16] P:\game\plugins\)
  #14 pmsrc/src/PocketMine(327): pocketmine\server()
  #15 pmsrc(11): require(string[52] phar://P:/game/PocketMine-MP.phar/src/PocketMine.php)
```